### PR TITLE
Fixed some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Beamium key points:
  - **Simple**: Beamium fetch Prometheus metrics and so benefits from an awesome community.
  - **Reliable**: Beamium handle network failure. Never lose data. We guarantee void proof graph ;)
  - **Versatile**: Beamium can also fetch metrics from a directory.
- - **Powerfull**: Beamium is able to filter metrics and to send them to multiple Warp10 platforms.
+ - **Powerful**: Beamium is able to filter metrics and to send them to multiple Warp10 platforms.
 
 ## Status
 Beamium is currently under development.
@@ -18,7 +18,7 @@ Beamium is currently under development.
 ## Building
 Beamium is pretty easy to build.
  - Clone the repository
- - Setup a minimal working config (see bellow)
+ - Setup a minimal working config (see below)
  - Build and run `cargo run`
 
 ## Configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -212,14 +212,15 @@ fn load_path<P: AsRef<Path>>(file_path: P, config: &mut Config) -> Result<(), Co
                 } else {
                     let f = try!(v["format"]
                         .as_str()
-                        .ok_or(format!("sinks.{}.format should be a string", name)));
+                        .ok_or(format!("sources.{}.format should be a string", name)));
 
                     if f == "prometheus" {
                         SourceFormat::Prometheus
                     } else if f == "sensision" {
                         SourceFormat::Sensision
                     } else {
-                        return Err(format!("sinks.{}.format should be 'Prometheus' or 'sensision'",
+                        return Err(format!("sources.{}.format should be 'prometheus' or \
+                                           'sensision'",
                                            name)
                             .into());
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,7 @@ pub fn load_config(config_path: &str) -> Result<Config, ConfigError> {
     Ok(config)
 }
 
-/// Extend confif from file.
+/// Extend config from file.
 fn load_path<P: AsRef<Path>>(file_path: P, config: &mut Config) -> Result<(), ConfigError> {
     let mut file = try!(File::open(file_path));
     let mut contents = String::new();

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,11 @@
 //! # Log module.
 //!
 //! The Config module provides the log facility.
-use slog::*;
+use slog::Logger;
+use slog::Level;
+use slog::Duplicate;
+use slog::LevelFilter;
+use slog::DrainExt;
 use slog_stream;
 use slog_term;
 use slog_json;

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn main() {
         }
     }
 
-    info!("shutding down");
+    info!("shutting down");
     for handle in handles {
         handle.join().unwrap();
     }


### PR DESCRIPTION
Fixed some typos I stumbled upon while reading the codebase:

* Some mistypings in the README, in a comment and in the "shutting down" log
* Two errors messages indicating errors in the sink config while being located within a check on the sources config (also corrected an upper case letter in an error while the check above was on the same word but all in lower case)

Signed-off-by: Brendan Abolivier <contact@brendanabolivier.com>