### PR TITLE
use scrapers instead of to be deprecated sources

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,4 +1,4 @@
-sources:
+scrapers:
   source1:
     url: http://127.0.0.1:9100/metrics
     period: 10000


### PR DESCRIPTION
Replace `sources` with `scrapers` in the example config to be consistent with documentation and avoid [deprecation message](https://github.com/runabove/beamium/blob/master/src/config.rs#L204).